### PR TITLE
chore: ignore omnisharp package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
       - nuget-org
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "OmniSharp.Extensions.Language*"
   - package-ecosystem: "nuget"
     directory: "src/PortingAssistantVSExtensionClient/"
     registries:


### PR DESCRIPTION
 Ignore omnisharp updates for PortingAssistantExtensionUnitTest package