### PR TITLE
test: remove ui test project reference from solution

### DIFF
--- a/src/PortingAssistantVSExtension.sln
+++ b/src/PortingAssistantVSExtension.sln
@@ -18,8 +18,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PortingAssistantExtensionUn
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PortingAssistantExtensionIntegTests", "..\tst\PortingAssistantExtensionIntegTests\PortingAssistantExtensionIntegTests.csproj", "{82311002-05CF-40B6-A5D1-9D7D6809A16C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortingAssistantExtensionUITests", "..\tst\PortingAssistantExtensionUITests\PortingAssistantExtensionUITests.csproj", "{54E36D90-BFBB-4F1A-945D-B7646F3AF88A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,10 +44,6 @@ Global
 		{82311002-05CF-40B6-A5D1-9D7D6809A16C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82311002-05CF-40B6-A5D1-9D7D6809A16C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82311002-05CF-40B6-A5D1-9D7D6809A16C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{54E36D90-BFBB-4F1A-945D-B7646F3AF88A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{54E36D90-BFBB-4F1A-945D-B7646F3AF88A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54E36D90-BFBB-4F1A-945D-B7646F3AF88A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54E36D90-BFBB-4F1A-945D-B7646F3AF88A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
*Description of changes:*
Remove UI Integration test project from solution in case it interferes in anyway with WCF release. 
No functional change as the test project is not required to be a part of the solution and can exist separately alongside. 

*Testing done:*
No functional change, code still builds locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.