### PR TITLE
fix: remove unused reference

### DIFF
--- a/src/PortingAssistantVSExtensionClient2022/PortingAssistantVSExtensionClient2022.csproj
+++ b/src/PortingAssistantVSExtensionClient2022/PortingAssistantVSExtensionClient2022.csproj
@@ -81,9 +81,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aws4RequestSigner">
-      <Version>1.0.3</Version>
-    </PackageReference>
     <PackageReference Include="AWSSDK.APIGateway">
       <Version>3.7.2.49</Version>
     </PackageReference>

--- a/src/PortingAssistantVSExtensionClient2022/packages.lock.json
+++ b/src/PortingAssistantVSExtensionClient2022/packages.lock.json
@@ -2,12 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.7.2": {
-      "Aws4RequestSigner": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "nRXdbKbNH85aLjmIst7q6v47Owh91RPB1DlkQqXAuVvrVHY1oTePjkAt/2/4L539PSwFMZchn/DK0pYpSsq3Og=="
-      },
       "AWSSDK.APIGateway": {
         "type": "Direct",
         "requested": "[3.7.2.49, )",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We removed the usage of the 3rd party signer nuget package in last release, but I missed removing the reference in the VS2022 client project

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.