### PR TITLE
Fix PortingAssistant IDE extension Target framework selection logic and dialogbox

### DIFF
--- a/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
@@ -100,15 +100,15 @@ namespace PortingAssistantVSExtensionClient.Commands
             {
                 if (!await CommandsCommon.CheckLanguageServerStatusAsync()) return;
                 if (!CommandsCommon.SetupPage()) return;
-                CommandsCommon.EnableAllCommand(false);
-                var SolutionFile = await CommandsCommon.GetSolutionPathAsync();
-                SolutionName = Path.GetFileName(SolutionFile);
                 if (UserSettings.Instance.TargetFramework.Equals(TargetFrameworkType.NO_SELECTION))
                 {
                     if (!SelectTargetDialog.EnsureExecute()) return;
                 }
+                CommandsCommon.EnableAllCommand(false);
+                var solutionFile = await CommandsCommon.GetSolutionPathAsync();
+                SolutionName = Path.GetFileName(solutionFile);
                 string pipeName = Guid.NewGuid().ToString();
-                CommandsCommon.RunAssessmentAsync(SolutionFile, pipeName);
+                await CommandsCommon.RunAssessmentAsync(solutionFile, pipeName);
                 PipeUtils.StartListenerConnection(pipeName, GetAssessmentCompletionTasks(this.package, SolutionName));
             }
             catch (Exception ex)

--- a/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
@@ -100,6 +100,7 @@ namespace PortingAssistantVSExtensionClient.Commands
             {
                 if (!await CommandsCommon.CheckLanguageServerStatusAsync()) return;
                 if (!CommandsCommon.SetupPage()) return;
+                // Verify Target framework selection before disabling all commands.
                 if (UserSettings.Instance.TargetFramework.Equals(TargetFrameworkType.NO_SELECTION))
                 {
                     if (!SelectTargetDialog.EnsureExecute()) return;

--- a/src/PortingAssistantExtensionClientShared/Dialogs/PortingDialog.xaml
+++ b/src/PortingAssistantExtensionClientShared/Dialogs/PortingDialog.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:local="clr-namespace:PortingAssistantVSExtensionClient.Dialogs"
-             mc:Ignorable="d" Height="218" Width="480">
+             mc:Ignorable="d" Height="218" Width="480" MinHeight="218" MinWidth="480">
     <Grid Margin="0,0,0,0" VerticalAlignment="Top">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>

--- a/src/PortingAssistantExtensionClientShared/Dialogs/SelectTargetDialog.xaml
+++ b/src/PortingAssistantExtensionClientShared/Dialogs/SelectTargetDialog.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:local="clr-namespace:PortingAssistantVSExtensionClient.Dialogs"
-             mc:Ignorable="d" Height="190" Width="480">
+             mc:Ignorable="d" Height="218" Width="480" MinHeight="218" MinWidth="480">
     <Grid Margin="0,0,0,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>


### PR DESCRIPTION
*Issue #,
PortingAssistant IDE extension Choose target framework dialog doesn't render Cancel or OK properly.
PortingAssistant IDE extension target framework dialog won't pop up if user select Cancel until restart VS.*

*Description of changes: Updated the dialog box so both Cancel and OK buttons are rendered properly.
Updated the logic when this dialog shows up for users that haven't chosen any target framework yet, so we validate their selection before disabling any buttons*

*Testing done: Locally verified the UI and logical changes*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.