### PR TITLE
fix: set dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "OmniSharp.Extensions.Language*"
   - package-ecosystem: "nuget"
@@ -22,14 +22,14 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "nuget"
     directory: "src/PortingAssistantExtensionUnitTest/"
     registries:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "OmniSharp.Extensions.Language*"
       - dependency-name: "Microsoft.VisualStudio.SDK"
@@ -39,4 +39,4 @@ updates:
       - porting-assistant-nuget
       - nuget-org
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Description
* Set dependabot to check for package updates on a weekly basis (checks on Monday by default)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.