### PR TITLE
[DRAFT] Handle initialization exceptions

### DIFF
--- a/src/PortingAssistantExtensionClientShared/Common/UserSettings.cs
+++ b/src/PortingAssistantExtensionClientShared/Common/UserSettings.cs
@@ -36,7 +36,9 @@ namespace PortingAssistantVSExtensionClient.Options
 
         private UserSettings()
         {
+#if !Dev17
             ThreadHelper.ThrowIfNotOnUIThread();
+#endif
             var sm = new ShellSettingsManager(ServiceProvider.GlobalProvider);
             _settingStore = sm.GetWritableSettingsStore(SettingsScope.UserSettings);
             this._languageServerStatus = new TaskCompletionSource<LanguageServerStatus>();

--- a/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
@@ -240,8 +240,12 @@ namespace PortingAssistantVSExtensionClient
 #if Dev17
         public Task<InitializationFailureContext> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState)
         {
-            var error = initializationState;
-            return (Task<InitializationFailureContext>)Task.CompletedTask;
+            var failureMessage = initializationState?.InitializationException?.ToString() ?? "Unknown reason for initialization failure.";
+            return Task.CompletedTask as Task<InitializationFailureContext>
+                   ?? Task.FromResult(new InitializationFailureContext
+                   {
+                       FailureMessage = failureMessage
+                   });
         }
 #endif
     }


### PR DESCRIPTION
*Description of changes:*
* Resolves the following exceptions in VS 2022 to create a more reliable experience:
  * When initialization fails, a type cast failure was occurring. This casting is now handled correctly.
  * The UserSettings singleton is designed such that it can only be instantiated by the UI thread. In VS 2022, UserSettings are attempted to be automatically instantiated on startup. This results in a Type Initialization failure that cannot be recovered from, creating errors whenever the UserSettings instance is accessed. VS 2022 now allows UserSettings to be instantiated by a background task.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.