### PR TITLE
feat: emit minor version of visual studio in metrics

### DIFF
--- a/src/PortingAssistantExtensionServer/Common/PALanguageServerConfiguration.cs
+++ b/src/PortingAssistantExtensionServer/Common/PALanguageServerConfiguration.cs
@@ -12,6 +12,8 @@
 
         private static string _visualStudioVersion { get; set; }
 
+        private static string _visualStudioFullVersion { get; set; }
+
         static PALanguageServerConfiguration()
         {
             _enabledContinuousAssessment = false;
@@ -77,6 +79,18 @@
             set
             {
                 _visualStudioVersion = value;
+            }
+        }
+
+        public static string VisualStudioFullVersion
+        {
+            get
+            {
+                return _visualStudioFullVersion;
+            }
+            set
+            {
+                _visualStudioFullVersion = value;
             }
         }
 

--- a/src/PortingAssistantExtensionServer/Program.cs
+++ b/src/PortingAssistantExtensionServer/Program.cs
@@ -36,6 +36,7 @@ namespace PortingAssistantExtensionServer
                 Common.PALanguageServerConfiguration.ExtensionVersion = args.Length == 1 ? "0.0.0" : args[3];
                 var vsClientVersion = args.Length == 1 ? Common.Constants.VS_UNKNOWN : args[4];
                 Common.PALanguageServerConfiguration.VisualStudioVersion = GetVSVersion(vsClientVersion);
+                PALanguageServerConfiguration.VisualStudioFullVersion = vsClientVersion;
                 Console.WriteLine($"Porting Assistant Version is {Common.PALanguageServerConfiguration.ExtensionVersion}");
                 Console.WriteLine($"Visual Studio Version is {Common.PALanguageServerConfiguration.VisualStudioVersion}");
                 var portingAssistantConfiguration = JsonSerializer.Deserialize<PortingAssistantIDEConfiguration>(File.ReadAllText(config));

--- a/src/PortingAssistantExtensionServer/Services/AnalysisService.cs
+++ b/src/PortingAssistantExtensionServer/Services/AnalysisService.cs
@@ -67,7 +67,8 @@ namespace PortingAssistantExtensionServer.Services
                 _request.settings.TargetFramework,
                 PALanguageServerConfiguration.ExtensionVersion,
                 PALanguageServerConfiguration.VisualStudioVersion,
-                DateTime.Now.Subtract(startTime).TotalMilliseconds);
+                DateTime.Now.Subtract(startTime).TotalMilliseconds,
+                PALanguageServerConfiguration.VisualStudioFullVersion);
                 CreateClientConnectionAsync(request.PipeName);
                 return solutionAnalysisResult;
             }
@@ -137,7 +138,8 @@ namespace PortingAssistantExtensionServer.Services
                     triggerType,
                     _request.settings.TargetFramework,
                     PALanguageServerConfiguration.ExtensionVersion,
-                    PALanguageServerConfiguration.VisualStudioVersion
+                    PALanguageServerConfiguration.VisualStudioVersion,
+                    PALanguageServerConfiguration.VisualStudioFullVersion
                     );
 
                 return result;
@@ -344,7 +346,8 @@ namespace PortingAssistantExtensionServer.Services
                 _request.settings.TargetFramework,
                 PALanguageServerConfiguration.ExtensionVersion,
                 PALanguageServerConfiguration.VisualStudioVersion,
-                diagnostics.Count);
+                diagnostics.Count,
+                PALanguageServerConfiguration.VisualStudioFullVersion);
 
             return diagnostics;
         }

--- a/src/PortingAssistantExtensionTelemetry/Collector.cs
+++ b/src/PortingAssistantExtensionTelemetry/Collector.cs
@@ -10,7 +10,11 @@ namespace PortingAssistantExtensionTelemetry
 {
     public static class Collector
     {
-        public static void SolutionAssessmentCollect(SolutionAnalysisResult result, string runId, string triggerType, string targetFramework, string extensionVersion, string visualStudioVersion, double time)
+        public static void SolutionAssessmentCollect(
+            SolutionAnalysisResult result, string runId, string triggerType,
+            string targetFramework, string extensionVersion,
+            string visualStudioVersion, double time,
+            string visualStudioFullVersion)
         {
             var sha256hash = SHA256.Create();
             var date = DateTime.Now;
@@ -30,6 +34,7 @@ namespace PortingAssistantExtensionTelemetry
                 SolutionGuid = result.SolutionDetails.SolutionGuid,
                 RepositoryUrl = result.SolutionDetails.RepositoryUrl,
                 AnalysisTime = time,
+                VisualStudioClientFullVersion = visualStudioFullVersion,
             };
             TelemetryCollector.Collect<SolutionMetrics>(solutionMetrics);
 
@@ -53,7 +58,8 @@ namespace PortingAssistantExtensionTelemetry
                     numNugets = projectAnalysisResult.PackageReferences.Count,
                     numReferences = projectAnalysisResult.ProjectReferences.Count,
                     isBuildFailed = projectAnalysisResult.IsBuildFailed,
-                    compatibilityResult = projectAnalysisResult.ProjectCompatibilityResult
+                    compatibilityResult = projectAnalysisResult.ProjectCompatibilityResult,
+                    VisualStudioClientFullVersion = visualStudioFullVersion
                 };
                 TelemetryCollector.Collect<ProjectMetrics>(projectMetrics);
 
@@ -77,6 +83,7 @@ namespace PortingAssistantExtensionTelemetry
                         pacakgeName = nuget.Value.Result.PackageVersionPair.PackageId,
                         packageVersion = nuget.Value.Result.PackageVersionPair.Version,
                         compatibility = nuget.Value.Result.CompatibilityResults[targetFramework].Compatibility,
+                        VisualStudioClientFullVersion = visualStudioFullVersion
                     };
                     TelemetryCollector.Collect<NugetMetrics>(nugetMetrics);
                 }
@@ -90,12 +97,15 @@ namespace PortingAssistantExtensionTelemetry
                     selectedApi?.Recommendations?.RecommendedActions?.Add(action);
                 });
 
-                FileAssessmentCollect(selectedApis, runId, triggerType, targetFramework, extensionVersion, visualStudioVersion);
+                FileAssessmentCollect(selectedApis, runId, triggerType, targetFramework, extensionVersion, visualStudioVersion, visualStudioFullVersion);
             });
         }
 
 
-        public static void FileAssessmentCollect(IEnumerable<ApiAnalysisResult> selectedApis , string runId, string triggerType, string targetFramework, string extensionVersion, string visualStudioVersion)
+        public static void FileAssessmentCollect(
+            IEnumerable<ApiAnalysisResult> selectedApis, string runId,
+            string triggerType, string targetFramework, string extensionVersion,
+            string visualStudioVersion, string visualStudioFullVersion)
         {
             var date = DateTime.Now;
             var apiMetrics = selectedApis.GroupBy(elem => new
@@ -122,12 +132,17 @@ namespace PortingAssistantExtensionTelemetry
                 packageVersion = group.First().CodeEntityDetails.Package.Version,
                 apiType = group.First().CodeEntityDetails.CodeEntityType.ToString(),
                 hasActions = group.First().Recommendations.RecommendedActions.Any(action => action.RecommendedActionType != RecommendedActionType.NoRecommendation),
-                apiCounts = group.Count()
+                apiCounts = group.Count(),
+                VisualStudioClientFullVersion = visualStudioFullVersion
             });
             apiMetrics.ToList().ForEach(metric => TelemetryCollector.Collect(metric));
         }
 
-        public static void ContinuousAssessmentCollect(SourceFileAnalysisResult result, string runId, string triggerType, string targetFramework, string extensionVersion, string visualStudioVersion, int diagnostics)
+        public static void ContinuousAssessmentCollect(
+            SourceFileAnalysisResult result, string runId, string triggerType,
+            string targetFramework, string extensionVersion,
+            string visualStudioVersion, int diagnostics,
+            string visualStudioFullVersion)
         {
             var timeStamp = DateTime.Now.ToString("MM/dd/yyyy HH:mm");
 
@@ -141,7 +156,8 @@ namespace PortingAssistantExtensionTelemetry
                 TargetFramework = targetFramework,
                 Diagnostics = diagnostics,
                 RunId = runId,
-                TriggerType = triggerType
+                TriggerType = triggerType,
+                VisualStudioClientFullVersion = visualStudioFullVersion
             });
         }
 

--- a/src/PortingAssistantExtensionTelemetry/Model/MetricsBase.cs
+++ b/src/PortingAssistantExtensionTelemetry/Model/MetricsBase.cs
@@ -13,5 +13,6 @@ namespace PortingAssistantExtensionTelemetry.Model
         public string TimeStamp { get; set; }
         public string RunId { get; set; }
         public string TriggerType { get; set; }
+        public string VisualStudioClientFullVersion { get; set; }
     }
 }


### PR DESCRIPTION
*Description of changes:*
Add new metric that captures the minor version of visual studio instead of just VS2022 vs VS2019.

*Testing done:*
Created VSIX and installed, Verified new metric was included in the metrics file.

*Note for Reviewer*
Currently the logic that grabs the visual studio version only grabs major and minor, that logic would have to be updated if we want build or revision numbers.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.