### PR TITLE
fix multiple flashbar

### DIFF
--- a/src/PortingAssistantExtensionClientShared/PortingAssistantExtensionClientShared.projitems
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantExtensionClientShared.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PortingAssistantLanguageClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PortingAssistantVSExtensionClientPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\AwsUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\CredentialsNotifications.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\NotificationUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\PipeUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\SolutionUtils.cs" />

--- a/src/PortingAssistantExtensionClientShared/PortingAssistantVSExtensionClientPackage.cs
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantVSExtensionClientPackage.cs
@@ -70,10 +70,8 @@ namespace PortingAssistantVSExtensionClient
                 for (; ; )
                 {
                     await Task.Delay(900000);
-                    if (AwsUtils.isDismissed)
-                    {
-                        await AwsUtils.ValidateProfileAsync();
-                    }
+                    await AwsUtils.ValidateProfileAsync();
+
                 }
             });
         }

--- a/src/PortingAssistantExtensionClientShared/PortingAssistantVSExtensionClientPackage.cs
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantVSExtensionClientPackage.cs
@@ -70,7 +70,10 @@ namespace PortingAssistantVSExtensionClient
                 for (; ; )
                 {
                     await Task.Delay(900000);
-                    await AwsUtils.ValidateProfileAsync();
+                    if (AwsUtils.isDismissed)
+                    {
+                        await AwsUtils.ValidateProfileAsync();
+                    }
                 }
             });
         }

--- a/src/PortingAssistantExtensionClientShared/Utils/AwsUtils.cs
+++ b/src/PortingAssistantExtensionClientShared/Utils/AwsUtils.cs
@@ -203,7 +203,7 @@ namespace PortingAssistantVSExtensionClient.Utils
                     ConfigurationFileName);
                 var TelemetryConfiguration = JsonConvert.DeserializeObject<PortingAssistantIDEConfiguration>(File.ReadAllText(ConfigurationPath)).TelemetryConfiguration;
 
-                if (awsCredentials == null || !await AwsUtils.VerifyUserAsync("", awsCredentials, TelemetryConfiguration))
+                if ((awsCredentials == null || !await AwsUtils.VerifyUserAsync("", awsCredentials, TelemetryConfiguration)) &&  isDismissed) 
                 {
                     var creds = new CredentialsNotifications();
                     await creds.ShowCredentialsInfoBarAsync(PAGlobalService.Instance.AsyncServiceProvider, "AWS Credentials associated with Porting Assistant for .NET may have Expired. Please refresh credentials.");

--- a/src/PortingAssistantExtensionClientShared/Utils/AwsUtils.cs
+++ b/src/PortingAssistantExtensionClientShared/Utils/AwsUtils.cs
@@ -14,6 +14,8 @@ using System.Threading.Tasks;
 using Amazon;
 using PortingAssistantVSExtensionClient.Options;
 using PortingAssistantVSExtensionClient.Common;
+using Microsoft.VisualStudio.Shell;
+using PortingAssistantExtensionClientShared.Utils;
 
 namespace PortingAssistantVSExtensionClient.Utils
 {
@@ -40,6 +42,7 @@ namespace PortingAssistantVSExtensionClient.Utils
     public static class AwsUtils
     {
         private static readonly SharedCredentialsFile sharedProfile = new SharedCredentialsFile();
+        public static bool isDismissed = true;
         public static List<string> ListProfiles()
         {
             return sharedProfile.ListProfileNames();
@@ -202,7 +205,8 @@ namespace PortingAssistantVSExtensionClient.Utils
 
                 if (awsCredentials == null || !await AwsUtils.VerifyUserAsync("", awsCredentials, TelemetryConfiguration))
                 {
-                    await NotificationUtils.ShowInfoBarAsync(PAGlobalService.Instance.AsyncServiceProvider, "AWS Credentials associated with Porting Assistant for .NET may have Expired. Please refresh credentials.");
+                    var creds = new CredentialsNotifications();
+                    await creds.ShowCredentialsInfoBarAsync(PAGlobalService.Instance.AsyncServiceProvider, "AWS Credentials associated with Porting Assistant for .NET may have Expired. Please refresh credentials.");
                     return false;
                 }
             }  

--- a/src/PortingAssistantExtensionClientShared/Utils/CredentialsNotifications.cs
+++ b/src/PortingAssistantExtensionClientShared/Utils/CredentialsNotifications.cs
@@ -1,0 +1,57 @@
+﻿using EnvDTE;
+using Microsoft;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using PortingAssistantVSExtensionClient.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PortingAssistantExtensionClientShared.Utils
+{
+    internal class CredentialsNotifications : IVsInfoBarUIEvents
+    {
+        private IVsShell shell;
+        private IVsInfoBarHost host;
+        private uint _cookie;
+        public async System.Threading.Tasks.Task ShowCredentialsInfoBarAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider ServiceProvider, string message)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            shell = await ServiceProvider.GetServiceAsync(typeof(SVsShell)) as IVsShell;
+            if (shell != null)
+            {
+                shell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var obj);
+                host = (IVsInfoBarHost)obj;
+
+                if (host != null)
+                {
+                    var actions = new List<IVsInfoBarActionItem>
+                    {
+                        new InfoBarHyperlink("Dismiss", "dismiss"),
+                    };
+                    InfoBarModel infoBarModel = new InfoBarModel(message, actions, KnownMonikers.StatusInformation, isCloseButtonVisible: false);
+                    var factory = await ServiceProvider.GetServiceAsync(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
+                    Assumes.Present(factory);
+                    IVsInfoBarUIElement element = factory.CreateInfoBar(infoBarModel);
+                    element.Advise(this, out _cookie);
+                    host.AddInfoBar(element);
+                    AwsUtils.isDismissed = false;
+                }
+            }
+        }
+
+        public void OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
+        {
+            host.RemoveInfoBar(infoBarUIElement);
+            infoBarUIElement.Unadvise(_cookie);
+            infoBarUIElement.Close();
+
+            AwsUtils.isDismissed = true;
+        }
+
+        void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
+        {
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
- Removed close button for the flashbar
- Added a custom dismiss button for the flashbar to track flashbar dismiss status.

- Raise flashbar only if there is not active flashbar

*Testing done:*
- Tested in debug mode with expired credentials
- Passed Test Scenario: Dismiss button should close the flashbar
- Passed Test Scenario: Only one flashbar displayed if credentials are expired
![Screen Shot 2022-05-17 at 6 49 21 PM](https://user-images.githubusercontent.com/10420554/168925374-e87758a7-56fd-42cd-92a4-0a441b5a2d9f.png)


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.