### PR TITLE
fix: logger creating extra files

### DIFF
--- a/src/PortingAssistantExtensionServer/Program.cs
+++ b/src/PortingAssistantExtensionServer/Program.cs
@@ -77,7 +77,7 @@ namespace PortingAssistantExtensionServer
                 
                 logTimer.Interval = Convert.ToDouble(portingAssistantConfiguration.TelemetryConfiguration.LogTimerInterval);
                 var lastReadTokenFile = Path.Combine(portingAssistantConfiguration.TelemetryConfiguration.LogsPath, "lastToken.json");
-                logTimer.Elapsed += (source, e) => LogUploadUtils.OnTimedEvent(source, e, PALanguageServerConfiguration.EnabledMetrics, portingAssistantConfiguration.TelemetryConfiguration, lastReadTokenFile, Common.PALanguageServerConfiguration.AWSProfileName, Common.PALanguageServerConfiguration.EnabledDefaultCredentials, Common.PALanguageServerConfiguration.ExtensionVersion);
+                logTimer.Elapsed += (source, e) => LogUploadUtils.OnTimedEvent(source, e, PALanguageServerConfiguration.EnabledMetrics, portingAssistantConfiguration.TelemetryConfiguration, lastReadTokenFile, Common.PALanguageServerConfiguration.AWSProfileName, Common.PALanguageServerConfiguration.EnabledDefaultCredentials, Common.PALanguageServerConfiguration.ExtensionVersion, Log.Logger);
                 logTimer.AutoReset = true;
                 logTimer.Enabled = true;
                 

--- a/src/PortingAssistantExtensionTelemetry/Utils/LogUploadUtils.cs
+++ b/src/PortingAssistantExtensionTelemetry/Utils/LogUploadUtils.cs
@@ -76,29 +76,13 @@ namespace PortingAssistantExtensionTelemetry.Utils
             string profile,
             bool enabledDefaultCredentials,
             string paVersion,
-            TelemetryConfiguration telemetryConfiguration
+            TelemetryConfiguration telemetryConfiguration,
+            AWSCredentials awsCredentials,
+            ILogger logger
             )
         {
             try
             {
-                var outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] (Porting Assistant IDE Extension) (" + paVersion + ") {SourceContext}: {Message:lj}{NewLine}{Exception}";
-                var logConfiguration = new LoggerConfiguration().Enrich.FromLogContext()
-                    .MinimumLevel.Warning()
-                    .WriteTo.File(
-                        telemetryConfiguration.LogFilePath,
-                        rollingInterval: RollingInterval.Day,
-                        rollOnFileSizeLimit: true,
-                        outputTemplate: outputTemplate);
-
-                Log.Logger = logConfiguration.CreateLogger();
-
-                AWSCredentials awsCredentials = GetAWSCredentials(profile, enabledDefaultCredentials);
-
-                if (awsCredentials == null)
-                {
-                    Log.Logger.Error("Log Upload Failed due to Invalid Credentials");
-                    return false;
-                }
 
                 var region = telemetryConfiguration.Region;
                 dynamic requestMetadata = new JObject();
@@ -132,16 +116,24 @@ namespace PortingAssistantExtensionTelemetry.Utils
             }
             catch (Exception ex)
             {
-                Log.Logger.Error("Log Upload Failed: " + ex.Message);
+                logger.Error("Log Upload Failed: " + ex.Message);
                 return false;
             }
         }
 
-        public static void OnTimedEvent(object source, System.Timers.ElapsedEventArgs e, bool shareMetric, TelemetryConfiguration teleConfig, string lastReadTokenFile, string profile, bool enabledDefaultCredentials, string paVersion)
+        public static void OnTimedEvent(object source, System.Timers.ElapsedEventArgs e, bool shareMetric, TelemetryConfiguration teleConfig, string lastReadTokenFile, string profile, bool enabledDefaultCredentials, string paVersion, ILogger logger)
         {
             try
             {
                 if (!shareMetric) return;
+
+                AWSCredentials awsCredentials = GetAWSCredentials(profile, enabledDefaultCredentials);
+                if (awsCredentials == null)
+                {
+                    logger.Error("Log Upload Failed. Could not retrieve any AWS Credentials");
+                    return;
+                }
+
                 // Get files in directory and filter based on Suffix
                 string[] fileEntries = Directory.GetFiles(teleConfig.LogsPath).Where(f =>
                   teleConfig.Suffix.ToArray().Any(x => f.EndsWith(x))
@@ -212,14 +204,28 @@ namespace PortingAssistantExtensionTelemetry.Utils
                                     if (logs.Count >= 1000)
                                     {
                                         // logs.TrimToSize();
-                                        success = PutLogData(logName, JsonConvert.SerializeObject(logs), profile, enabledDefaultCredentials, paVersion, teleConfig).Result;
+                                        success = PutLogData(logName,
+                                                JsonConvert.SerializeObject(logs),
+                                                profile,
+                                                enabledDefaultCredentials,
+                                                paVersion,
+                                                teleConfig,
+                                                awsCredentials,
+                                                logger).Result;
                                         if (success) { logs = new ArrayList(); };
                                     }
                                 }
 
                                 if (logs.Count != 0)
                                 {
-                                    success = PutLogData(logName, JsonConvert.SerializeObject(logs), profile, enabledDefaultCredentials, paVersion, teleConfig).Result;
+                                    success = PutLogData(logName,
+                                            JsonConvert.SerializeObject(logs),
+                                            profile,
+                                            enabledDefaultCredentials,
+                                            paVersion,
+                                            teleConfig,
+                                            awsCredentials,
+                                            logger).Result;
                                 }
                                 if (success)
                                 {
@@ -234,7 +240,7 @@ namespace PortingAssistantExtensionTelemetry.Utils
             }
             catch (Exception ex)
             {
-                Log.Logger.Error("Log Upload Failed: " + ex.Message);
+                logger.Error("Log Upload Failed: " + ex.Message);
             }
         }
     }

--- a/src/PortingAssistantExtensionTelemetry/Utils/LogUploadUtils.cs
+++ b/src/PortingAssistantExtensionTelemetry/Utils/LogUploadUtils.cs
@@ -23,7 +23,6 @@ namespace PortingAssistantExtensionTelemetry.Utils
         private static bool IsFileLocked(FileInfo file)
         {
             FileStream stream = null;
-
             try
             {
                 stream = file.Open


### PR DESCRIPTION
*Description of changes:*
Consolidate new telemetry logger into the existing logger. This new logger would create new files during telemetry upload failures which would in turn create more upload requests.

Also move aws credentials check outside the files loop to reduce number of api calls if we cannot get credentials a little further

*Testing done:*
Tested manually and verified that the logs were all coming into a single file instead of generating new files.

<img width="1122" alt="Screen Shot 2022-04-30 at 10 40 21 AM" src="https://user-images.githubusercontent.com/4431742/166116508-79d68bc8-7ea6-4cf0-a632-b0d2e6f902c1.png">

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x]  I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.