### PR TITLE
fix: check for vb and cs project files

### DIFF
--- a/src/PortingAssistantExtensionServer/TextDocumentModels/CodeFileDocument.cs
+++ b/src/PortingAssistantExtensionServer/TextDocumentModels/CodeFileDocument.cs
@@ -40,7 +40,8 @@ namespace PortingAssistantExtensionServer.TextDocumentModels
 
             while (!string.IsNullOrEmpty(currentDir))
             {
-                projectFile = Directory.EnumerateFiles(currentDir, "*.csproj").FirstOrDefault();
+                projectFile = Directory.EnumerateFiles(currentDir, "*.csproj").FirstOrDefault() ??
+                              Directory.EnumerateFiles(currentDir, "*.vbproj").FirstOrDefault();
                 if (projectFile != null)
                 {
                     return projectFile;


### PR DESCRIPTION
*Description of changes:*
Fix path is null or empty error when checking for project file. Need to account for both .csproj and .vbproj project files now with VB support.

*Testing done:*
manually tested by debugging ide extension

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.