### PR TITLE
fix: activate lanugage server for vb in 2019

### DIFF
--- a/src/PortingAssistantExtensionClientShared/Commands/CommandsCommon.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/CommandsCommon.cs
@@ -70,15 +70,17 @@ namespace PortingAssistantVSExtensionClient.Commands
                 await NotificationUtils.UseStatusBarProgressAsync(1, 2, "Check Porting Assistant Status.....");
                 var serverStatus = await UserSettings.Instance.GetLanguageServerStatusAsync();
                 await NotificationUtils.UseStatusBarProgressAsync(2, 2, "");
-                if (serverStatus == LanguageServerStatus.NOT_RUNNING)
+                int retryInterval = 3000;
+                for (int retry = 0; retry < 3 ; retry++)
                 {
-                    NotificationUtils.ShowInfoMessageBox(PAGlobalService.Instance.Package, "Porting Assistant cannot be activated. Please open any .cs/.vb file if its not already opened.", "Porting Assistant can not be activated.");
-                    return false;
+
+                    if (serverStatus == LanguageServerStatus.NOT_RUNNING)
+                    {
+                        System.Threading.Thread.Sleep(retryInterval);
+                    }
+                    else return true;
                 }
-                else
-                {
-                    return true;
-                }
+                return false;
 
             }catch(Exception ex)
             {

--- a/src/PortingAssistantExtensionClientShared/Commands/ProjectPortingCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/ProjectPortingCommand.cs
@@ -100,7 +100,11 @@ namespace PortingAssistantVSExtensionClient.Commands
         {
             try
             {
-                if (!await CommandsCommon.CheckLanguageServerStatusAsync()) return;
+                if (!await CommandsCommon.CheckLanguageServerStatusAsync())
+                {
+                    NotificationUtils.ShowInfoMessageBox(PAGlobalService.Instance.Package, "Porting Assistant cannot be activated. Please open any .cs/.vb file if its not already opened.", "Porting Assistant can not be activated.");
+                    return;
+                }
                 if (!CommandsCommon.SetupPage()) return;
                 string SelectedProjectPath = SolutionUtils.GetSelectedProjectPath();
                 selectedProjectName = Path.GetFileName(SelectedProjectPath);

--- a/src/PortingAssistantExtensionClientShared/Commands/SolutionPortingCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/SolutionPortingCommand.cs
@@ -98,7 +98,11 @@ namespace PortingAssistantVSExtensionClient.Commands
         {
             try
             {
-                if (!await CommandsCommon.CheckLanguageServerStatusAsync()) return;
+                if (!await CommandsCommon.CheckLanguageServerStatusAsync())
+                {
+                    NotificationUtils.ShowInfoMessageBox(PAGlobalService.Instance.Package, "Porting Assistant cannot be activated. Please open any .cs/.vb file if its not already opened.", "Porting Assistant can not be activated.");
+                    return;
+                }
                 if (!CommandsCommon.SetupPage()) return;
                 if (!UserSettings.Instance.SolutionAssessed)
                 {

--- a/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
@@ -43,7 +43,7 @@ namespace PortingAssistantVSExtensionClient
     {
         [Export]
         [Name("VisualBasicFileType")]
-        [BaseDefinition("Basic")]
+        [BaseDefinition("Code")]
         internal static ContentTypeDefinition VbContentTypeDefinition;
 
         [Export]
@@ -52,8 +52,23 @@ namespace PortingAssistantVSExtensionClient
         internal static FileExtensionToContentTypeDefinition VbFileExtensionDefinition;
     }
 
-    [ContentType("CSharpFileType")]
-    [ContentType("VisualBasicFileType")]
+    class PAcContentDefinition
+    {
+        [Export]
+        [Name("ini")]
+        [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
+        internal static ContentTypeDefinition IniContentTypeDefinition;
+
+        [Export]
+        [FileExtension(".ini")]
+        [ContentType("ini")]
+        internal static FileExtensionToContentTypeDefinition IniFileExtensionDefinition;
+    }
+
+    [ContentType("CSharpFileType"), ContentType("VisualBasicFileType")]
+#if Dev16
+    [ContentType("ini")]
+#endif
     [Export(typeof(ILanguageClient))]
     [Guid(PortingAssistantLanguageClient.PackageGuidString)]
     class PortingAssistantLanguageClient : AsyncPackage, ILanguageClient, ILanguageClientCustomMessage2

--- a/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
+++ b/src/PortingAssistantExtensionClientShared/PortingAssistantLanguageClient.cs
@@ -52,7 +52,7 @@ namespace PortingAssistantVSExtensionClient
         internal static FileExtensionToContentTypeDefinition VbFileExtensionDefinition;
     }
 
-    class PAcContentDefinition
+    class PAContentDefinition
     {
         [Export]
         [Name("ini")]

--- a/src/PortingAssistantVSExtensionClient2019/PortingAssistantVSExtensionClient2019.csproj
+++ b/src/PortingAssistantVSExtensionClient2019/PortingAssistantVSExtensionClient2019.csproj
@@ -86,15 +86,15 @@
     <PackageReference Include="AWSSDK.Core">
       <Version>3.7.3.5</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31025.194" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.10.31">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.2021">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
can not activate vb content type in visual studio due to vs sdk bug  in VB BaseDefinition (it is fixed in vs sdk 17, so no issue in vs 2022).

*Description of changes:*
trigger dummy file to activate language server.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.