### PR TITLE
fix: set file size limit for log files to 1 MB

### DIFF
--- a/src/PortingAssistantExtensionServer/Program.cs
+++ b/src/PortingAssistantExtensionServer/Program.cs
@@ -53,7 +53,8 @@ namespace PortingAssistantExtensionServer
                         portingAssistantConfiguration.TelemetryConfiguration.LogFilePath,
                         rollingInterval: RollingInterval.Day,
                         rollOnFileSizeLimit: true,
-                        outputTemplate: outputTemplate);
+                        outputTemplate: outputTemplate,
+                        fileSizeLimitBytes: 1000000);
                 if (isConsole)
                 {
                     logConfiguration = logConfiguration.WriteTo.Console();


### PR DESCRIPTION
*Description of changes:*
cap log files size at 1 MB, since it does max 1000 lines per file, it should never hit the cap of 10MB for API gateway, and it will add consistency to log files.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.