### PR TITLE
fix: IDE extension assessment never finish issue

### DIFF
--- a/src/PortingAssistantExtensionClientShared/Commands/ProjectPortingCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/ProjectPortingCommand.cs
@@ -145,13 +145,20 @@ namespace PortingAssistantVSExtensionClient.Commands
                 try
                 {
                     var successfulMessage = $"The project has been ported to {targetFramework}" + (UserSettings.Instance.ApplyPortAction? $".{Environment.NewLine}Code changes have been applied" : "");
-                    NotificationUtils.ShowInfoMessageBox(package, successfulMessage, "Porting successful");
+                    NotificationUtils.ShowInfoMessageBox(
+                        package,
+                        successfulMessage,
+                        "Porting successful");
+
                     await NotificationUtils.ShowInfoBarAsync(package, successfulMessage);
                     await NotificationUtils.UseStatusBarProgressAsync(2, 2, successfulMessage);
                 }
                 catch (Exception ex)
                 {
-                    NotificationUtils.ShowErrorMessageBox(package, $"Porting failed for {selectedProject} due to {ex.Message}", "Porting failed");
+                    NotificationUtils.ShowErrorMessageBox(
+                        package,
+                        $"Porting failed for {selectedProject} due to {ex.Message}",
+                        "Porting failed");
                 }
                 finally
                 {

--- a/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
+++ b/src/PortingAssistantExtensionClientShared/Commands/SolutionAssessmentCommand.cs
@@ -145,12 +145,17 @@ namespace PortingAssistantVSExtensionClient.Commands
                         await PortingAssistantLanguageClient.UpdateUserSettingsAsync();
                     }
                     await NotificationUtils.UseStatusBarProgressAsync(2, 2, "Assessment successful");
-                    await NotificationUtils.ShowInfoBarAsync(this.package, "Assessment successful. You can view the assessment results in the error list or view the green highlights in your source code.");
+                    await NotificationUtils.ShowInfoBarAsync(
+                        this.package,
+                        "Assessment successful. You can view the assessment results in the error list or view the green highlights in your source code.");
                     UserSettings.Instance.SolutionAssessed = true;
                 }
                 catch (Exception ex)
                 {
-                    NotificationUtils.ShowErrorMessageBox(package, $"Assessment failed for {solutionName} due to {ex.Message}", "Assessment failed");
+                    NotificationUtils.ShowErrorMessageBox(
+                        package,
+                        $"Assessment failed for {solutionName} due to {ex.Message}",
+                        "Assessment failed");
                 }
                 finally
                 {

--- a/src/PortingAssistantExtensionServer/Services/AnalysisService.cs
+++ b/src/PortingAssistantExtensionServer/Services/AnalysisService.cs
@@ -61,16 +61,16 @@ namespace PortingAssistantExtensionServer.Services
                 var solutionAnalysisResult = await _client.AnalyzeSolutionAsync(request.solutionFilePath, request.settings);
 
                 Collector.SolutionAssessmentCollect(
-                solutionAnalysisResult,
-                runId,
-                triggerType,
-                _request.settings.TargetFramework,
-                PALanguageServerConfiguration.ExtensionVersion,
-                PALanguageServerConfiguration.VisualStudioVersion,
-                DateTime.Now.Subtract(startTime).TotalMilliseconds,
-                PALanguageServerConfiguration.VisualStudioFullVersion,
-                PALanguageServerConfiguration.EnabledDefaultCredentials);
-                CreateClientConnectionAsync(request.PipeName);
+                    solutionAnalysisResult,
+                    runId,
+                    triggerType,
+                    _request.settings.TargetFramework,
+                    PALanguageServerConfiguration.ExtensionVersion,
+                    PALanguageServerConfiguration.VisualStudioVersion,
+                    DateTime.Now.Subtract(startTime).TotalMilliseconds,
+                    PALanguageServerConfiguration.VisualStudioFullVersion,
+                    PALanguageServerConfiguration.EnabledDefaultCredentials);
+
                 return solutionAnalysisResult;
             }
             catch (Exception ex)
@@ -89,6 +89,10 @@ namespace PortingAssistantExtensionServer.Services
                         }
                     },
                 };
+            }
+            finally
+            {
+                CreateClientConnectionAsync(request.PipeName);
             }
         }
 

--- a/src/PortingAssistantExtensionServer/Services/PortingService.cs
+++ b/src/PortingAssistantExtensionServer/Services/PortingService.cs
@@ -82,7 +82,6 @@ namespace PortingAssistantExtensionServer.Services
                 };
                 _logger.LogInformation($"start porting ${request} .....");
                 var results = _client.ApplyPortingChanges(portingRequst);
-                CreateClientConnectionAsync(request.PipeName);
                 _logger.LogInformation($"porting success ${request.SolutionPath}");
                 return new ProjectFilePortingResponse()
                 {
@@ -100,6 +99,10 @@ namespace PortingAssistantExtensionServer.Services
                     messages = new List<string>() { ex.Message },
                     SolutionPath = request.SolutionPath
                 };
+            }
+            finally
+            {
+                CreateClientConnectionAsync(request.PipeName);
             }
         }
 

--- a/src/PortingAssistantExtensionTelemetry/Collector.cs
+++ b/src/PortingAssistantExtensionTelemetry/Collector.cs
@@ -11,15 +11,29 @@ namespace PortingAssistantExtensionTelemetry
     public static class Collector
     {
         public static void SolutionAssessmentCollect(
-            SolutionAnalysisResult result, string runId, string triggerType,
-            string targetFramework, string extensionVersion,
-            string visualStudioVersion, double time,
+            SolutionAnalysisResult result,
+            string runId,
+            string triggerType,
+            string targetFramework,
+            string extensionVersion,
+            string visualStudioVersion,
+            double time,
             string visualStudioFullVersion,
             bool useDefaultCredentials)
         {
+            if (result == null)
+            {
+                return;
+            }
+
             var sha256hash = SHA256.Create();
             var date = DateTime.Now;
             var solutionDetail = result.SolutionDetails;
+            if (solutionDetail == null)
+            {
+                return;
+            }
+
             // Solution Metrics
             var solutionMetrics = new SolutionMetrics
             {
@@ -40,7 +54,7 @@ namespace PortingAssistantExtensionTelemetry
             };
             TelemetryCollector.Collect<SolutionMetrics>(solutionMetrics);
 
-            result.ProjectAnalysisResults.ForEach(projectAnalysisResult => {
+            result.ProjectAnalysisResults?.ForEach(projectAnalysisResult => {
                 if (projectAnalysisResult == null) 
                 {
                     return;
@@ -71,7 +85,7 @@ namespace PortingAssistantExtensionTelemetry
             });
 
             //nuget metrics
-            result.ProjectAnalysisResults.ForEach(project =>
+            result.ProjectAnalysisResults?.ForEach(project =>
             {
                 foreach (var nuget in project.PackageAnalysisResults)
                 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Language server assessment caught exception from PortingAssistantClient, but previously skipped the pipe notification, which tells the IDE client that the assessment is done. By adding finally block, make sure the pipe notification always execute.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/porting-assistant-dotnet-ui/blob/develop/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including READMEs and comments (where appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.